### PR TITLE
Ensure that the CMake build type is respected also for multi-config generators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,9 +135,9 @@ class CMakeBuild(build_ext):
             ["cmake", str(_ROOT_DIR)] + cmake_args, cwd=self.build_temp
         )
         print("Calling cmake --build", flush=True)
-        subprocess.check_call(["cmake", "--build", "."], cwd=self.build_temp)
+        subprocess.check_call(["cmake", "--build", ".","--config",cmake_build_type], cwd=self.build_temp)
         print("Calling cmake --install", flush=True)
-        subprocess.check_call(["cmake", "--install", "."], cwd=self.build_temp)
+        subprocess.check_call(["cmake", "--install", ".","--config",cmake_build_type], cwd=self.build_temp)
 
     def copy_extensions_to_source(self):
         """Copy built extensions from temporary folder back into source tree.


### PR DESCRIPTION
@NicolasHug I am not sure if this is the problem, but for sure it is a problem. You are not explicitly setting any CMake generator, so you are using the default one. On Unix it is the [`Unix Makefiles` generator](https://cmake.org/cmake/help/latest/generator/Unix%20Makefiles.html) that is a usual single config generator, i.e. a generator that generates build files just for a single cmake build type. Instead, on Windows the default generator is [`Visual Studio 17 2022`](https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html), that is a multi-config generator, meaning that it generates build files for multiple configurations, and the configuration to use needs to be selected at build time with the `--config` option.